### PR TITLE
docs(#16): Add information about how to create the website infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ After you configured everything you can deploy infrastructure by running such co
 - `make terraspace-all-validate`
 - `make terraspace-all-up`
 
-After you deployed infrastructure you can trigger CI/CD for website setup by running such command.
+After you deployed you can create the website infrastructure itself using.
 - `terraspace all up`
 
 ## Using make

--- a/README.md
+++ b/README.md
@@ -164,6 +164,23 @@ After you configured everything you can deploy infrastructure by running such co
 After you deployed you can create the website infrastructure itself using.
 - `terraspace all up`
 
+### Instructions on how to set up and run the changes in AWS
+
+CLI Instructions:
+Once you have made the changes, you can run the pipeline using the `make` capabilities. If you already have the infrastructure, don't forget to apply the changes before running the pipeline.
+
+> make trigger-pipeline
+
+Run the command for each pipeline specifying its name, see the list of `make` possibilities for details on how to properly run this trigger
+
+
+AWS Management Console Instructions:
+Before running, make sure you have applied the changes made earlier.
+
+Search -> Codepipeline -> Pipelines -> Select a pipeline using the checkbox on the left -> Release change -> Release 
+
+Follow these steps for each pipeline. 
+
 ## Using make
 
 You can use `make` command to easily control and work with project locally.
@@ -200,6 +217,7 @@ The list of the `make` possibilities:
   terraspace-output-file         Output the stack variables into file. Variables: env, stack, out.
   terraspace-output              Output the stack variables. Variables: env, stack.
   terraspace-down                Down the stack. Variables: env, stack.
+  trigger-pipeline:              Trigger AWS CodePipeline. Variables: pipeline. Example: make trigger-pipeline pipeline=ci-cd-infra-test-pipeline
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ After you configured everything you can deploy infrastructure by running such co
 - `make terraspace-all-validate`
 - `make terraspace-all-up`
 
+After you deployed infrastructure you can trigger CI/CD for website setup by running such command.
+- `terraspace all up`
 
 ## Using make
 


### PR DESCRIPTION
## Description
Adding information how to create the website infrastructure.


## Tasks
- [ ] fix README.md file


## Acceptance Criteria
- [ ] README.md file fixed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced instructions for deploying infrastructure and running pipelines in AWS.
	- Added guidance for creating website infrastructure post-deployment using `terraspace all up`.
	- Expanded CLI instructions for using the `make` command to trigger pipelines.
	- Updated AWS Management Console section with a step-by-step guide for CodePipeline releases.
	- Introduced a new entry for `trigger-pipeline` in the `make` command options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->