### PR TITLE
fix(#69): add comment about sandbox deploy stage failure

### DIFF
--- a/aws/buildspecs/sandbox/deploy.yml
+++ b/aws/buildspecs/sandbox/deploy.yml
@@ -73,6 +73,34 @@ phases:
       - "echo #### Create EventBridge Rule"
       - ". ${CODEBUILD_SRC_DIR}/aws/scripts/sh/create_eventbridge_rule.sh"
 
+  post_build:
+    commands:
+      - |
+        echo "Post-build phase: Checking if build failed to post comment..."
+
+        if [ "$CODEBUILD_BUILD_SUCCEEDING" != "1" ]; then
+          # Get GitHub token for authentication
+          SECRET_ID=$(aws secretsmanager list-secrets --query "SecretList[?starts_with(Name, 'github-token-') && DeletedDate==null].Name" --output text)
+          if [ -z "$SECRET_ID" ]; then
+            echo "Error: No active GitHub token secret found for post-build comment."
+          else
+            aws secretsmanager get-secret-value --secret-id "$SECRET_ID" --query 'SecretString' --output text | jq -r '.token' | gh auth login --with-token
+
+            COMMENT_BODY="❌ Sandbox Deployment Failed
+            The deployment to the sandbox environment has failed.
+            Please review the CodeBuild logs and try again. 🔧"
+            
+            # Post the comment to the PR
+            if ! gh pr comment "$PR_NUMBER" -R "$GITHUB_REPOSITORY" --body "$COMMENT_BODY"; then
+              echo "Failed to add failure comment to PR, but not failing the build for this."
+            else
+              echo "Successfully posted build failure comment to PR #$PR_NUMBER"
+            fi
+          fi
+        else
+          echo "Build succeeded - no failure comment needed."
+        fi
+
 artifacts:
   files:
     - "**/*"

--- a/aws/buildspecs/sandbox/deploy.yml
+++ b/aws/buildspecs/sandbox/deploy.yml
@@ -22,17 +22,7 @@ phases:
       - nohup /usr/local/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --storage-driver=overlay2 &
       - timeout 15 sh -c "until docker info; do echo 'Waiting for Docker to start...'; sleep 1; done"
       - ". ${CODEBUILD_SRC_DIR}/aws/scripts/sh/sandbox_installation.sh"
-      - echo "Retrieving and using GitHub token for authentication..."
-      - |
-        SECRET_ID=$(aws secretsmanager list-secrets --query "SecretList[?starts_with(Name, 'github-token-') && DeletedDate==null].Name" --output text)
-        if [ -z "$SECRET_ID" ]; then
-          echo "Error: No active GitHub token secret found."
-          exit 1
-        fi
-        aws secretsmanager get-secret-value --secret-id "$SECRET_ID" --query 'SecretString' --output text | jq -r '.token' | gh auth login --with-token || {
-          echo "GitHub authentication failed"
-          exit 1
-        }
+      - ". ${CODEBUILD_SRC_DIR}/aws/scripts/sh/gh_auth_login.sh"
 
   build:
     commands:
@@ -40,16 +30,7 @@ phases:
         COMMENT_BODY="The deployment process for the sandbox has started.
         Please wait until the latest version is ready"
 
-        SECRET_ID=$(aws secretsmanager list-secrets --query 'SecretList[?starts_with(Name, `github-token-`) && DeletedDate==null].Name' --output text)
-        if [ -z "$SECRET_ID" ]; then
-          echo "Error: No active GitHub token secret found."
-          exit 1
-        fi
-
-        aws secretsmanager get-secret-value --secret-id "$SECRET_ID" --query 'SecretString' --output text | jq -r '.token' | gh auth login --with-token || {
-          echo "GitHub authentication failed"
-          exit 1
-        }
+        . ${CODEBUILD_SRC_DIR}/aws/scripts/sh/gh_auth_login.sh
 
         if ! gh pr comment "$PR_NUMBER" -R "$GITHUB_REPOSITORY" --body "$COMMENT_BODY"; then
           echo "Failed to add comment to PR"
@@ -79,23 +60,18 @@ phases:
         echo "Post-build phase: Checking if build failed to post comment..."
 
         if [ "$CODEBUILD_BUILD_SUCCEEDING" != "1" ]; then
-          # Get GitHub token for authentication
-          SECRET_ID=$(aws secretsmanager list-secrets --query "SecretList[?starts_with(Name, 'github-token-') && DeletedDate==null].Name" --output text)
-          if [ -z "$SECRET_ID" ]; then
-            echo "Error: No active GitHub token secret found for post-build comment."
-          else
-            aws secretsmanager get-secret-value --secret-id "$SECRET_ID" --query 'SecretString' --output text | jq -r '.token' | gh auth login --with-token
+          # Use the GitHub auth script with non-exit behavior for post-build
+          if . ${CODEBUILD_SRC_DIR}/aws/scripts/sh/gh_auth_login.sh false; then
+            COMMENT_BODY="❌ Sandbox Deployment Failed"$'\n'"The deployment to the sandbox environment has failed."$'\n'"Please review the CodeBuild logs and try again. 🔧"
 
-            COMMENT_BODY="❌ Sandbox Deployment Failed
-            The deployment to the sandbox environment has failed.
-            Please review the CodeBuild logs and try again. 🔧"
-            
             # Post the comment to the PR
             if ! gh pr comment "$PR_NUMBER" -R "$GITHUB_REPOSITORY" --body "$COMMENT_BODY"; then
               echo "Failed to add failure comment to PR, but not failing the build for this."
             else
               echo "Successfully posted build failure comment to PR #$PR_NUMBER"
             fi
+          else
+            echo "GitHub authentication failed - skipping failure comment."
           fi
         else
           echo "Build succeeded - no failure comment needed."

--- a/aws/buildspecs/sandbox/healthcheck.yml
+++ b/aws/buildspecs/sandbox/healthcheck.yml
@@ -41,6 +41,14 @@ phases:
           echo "Error: Required environment variable PROJECT_NAME is not set or empty."
           exit 1
         fi
+        if [ -z "${PR_NUMBER}" ]; then
+          echo "Error: Required environment variable PR_NUMBER is not set or empty."
+          exit 1
+        fi
+        if [ -z "${GITHUB_REPOSITORY}" ]; then
+          echo "Error: Required environment variable GITHUB_REPOSITORY is not set or empty."
+          exit 1
+        fi
       - ". ${CODEBUILD_SRC_DIR}/aws/scripts/sh/sanitize_branch.sh"
       - |
         echo "## Preparing Health Check for S3 Bucket..."
@@ -63,17 +71,8 @@ phases:
           "$HURL_FILE_PATH"; then
           echo "Health check failed. Adding comment to PR..."
 
-        SECRET_ID=$(aws secretsmanager list-secrets --query 'SecretList[?starts_with(Name, `github-token-`) && DeletedDate==null].Name' --output text)
-        if [ -z "$SECRET_ID" ]; then
-          echo "Error: No active GitHub token secret found."
-          exit 1
-        fi
-
-          echo "Retrieving and using GitHub token for authentication..."
-          aws secretsmanager get-secret-value --secret-id "$SECRET_ID" --query 'SecretString' --output text | jq -r '.token' | gh auth login --with-token || {
-            echo "GitHub authentication failed"
-            exit 1
-          }
+          # Use the GitHub authentication script
+          . ${CODEBUILD_SRC_DIR}/aws/scripts/sh/gh_auth_login.sh
 
           COMMENT_BODY=":x: Health check failed for the sandbox bucket.
           Please check the CodeBuild logs for detailed error information."

--- a/aws/buildspecs/sandbox/healthcheck.yml
+++ b/aws/buildspecs/sandbox/healthcheck.yml
@@ -72,7 +72,7 @@ phases:
           echo "Health check failed. Adding comment to PR..."
 
           # Use the GitHub authentication script
-          . ${CODEBUILD_SRC_DIR}/aws/scripts/sh/gh_auth_login.sh
+          . "${CODEBUILD_SRC_DIR}/aws/scripts/sh/gh_auth_login.sh"
 
           COMMENT_BODY=":x: Health check failed for the sandbox bucket.
           Please check the CodeBuild logs for detailed error information."

--- a/aws/scripts/sh/gh_auth_login.sh
+++ b/aws/scripts/sh/gh_auth_login.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# GitHub Authentication Script
+# This script handles GitHub CLI authentication using AWS Secrets Manager
+# Usage: source gh_auth_login.sh [exit_on_failure]
+# 
+# Parameters:
+#   exit_on_failure: Set to "true" to exit on authentication failure (default: true)
+#                   Set to "false" to continue execution on failure
+
+set -e
+
+EXIT_ON_FAILURE=${1:-true}
+
+echo "Retrieving GitHub token for authentication..."
+
+# Configure git to handle CodeBuild environment ownership issues
+git config --global --add safe.directory /codebuild/output/srcDownload/src 2>/dev/null || true
+git config --global --add safe.directory ${CODEBUILD_SRC_DIR} 2>/dev/null || true
+git config --global --add safe.directory "*" 2>/dev/null || true
+
+# Get the GitHub token secret ID
+SECRET_ID=$(aws secretsmanager list-secrets --query "SecretList[?starts_with(Name, 'github-token-') && DeletedDate==null].Name" --output text)
+
+if [ -z "$SECRET_ID" ]; then
+  echo "Error: No active GitHub token secret found."
+  if [ "$EXIT_ON_FAILURE" = "true" ]; then
+    exit 1
+  else
+    echo "Continuing without GitHub authentication..."
+    return 1 2>/dev/null || exit 1
+  fi
+fi
+
+# Retrieve and use the token for GitHub CLI authentication
+if aws secretsmanager get-secret-value --secret-id "$SECRET_ID" --query 'SecretString' --output text | jq -r '.token' | gh auth login --with-token; then
+  echo "GitHub authentication successful."
+  return 0 2>/dev/null || exit 0
+else
+  echo "GitHub authentication failed."
+  if [ "$EXIT_ON_FAILURE" = "true" ]; then
+    exit 1
+  else
+    echo "Continuing without GitHub authentication..."
+    return 1 2>/dev/null || exit 1
+  fi
+fi 

--- a/aws/scripts/sh/gh_auth_login.sh
+++ b/aws/scripts/sh/gh_auth_login.sh
@@ -3,14 +3,8 @@
 # GitHub Authentication Script
 # This script handles GitHub CLI authentication using AWS Secrets Manager
 # Usage: source gh_auth_login.sh [exit_on_failure]
-# 
-# Parameters:
-#   exit_on_failure: Set to "true" to exit on authentication failure (default: true)
-#                   Set to "false" to continue execution on failure
 
 set -e
-
-EXIT_ON_FAILURE=${1:-true}
 
 echo "Retrieving GitHub token for authentication..."
 
@@ -22,12 +16,7 @@ SECRET_ID=$(aws secretsmanager list-secrets --query "SecretList[?starts_with(Nam
 
 if [ -z "$SECRET_ID" ]; then
   echo "Error: No active GitHub token secret found."
-  if [ "$EXIT_ON_FAILURE" = "true" ]; then
-    exit 1
-  else
-    echo "Continuing without GitHub authentication..."
-    exit 1
-  fi
+  exit 1
 fi
 
 # Retrieve and use the token for GitHub CLI authentication
@@ -36,10 +25,5 @@ if aws secretsmanager get-secret-value --secret-id "$SECRET_ID" --query 'SecretS
   exit 0
 else
   echo "GitHub authentication failed."
-  if [ "$EXIT_ON_FAILURE" = "true" ]; then
-    exit 1
-  else
-    echo "Continuing without GitHub authentication..."
-    exit 1
-  fi
+  exit 1
 fi 

--- a/aws/scripts/sh/gh_auth_login.sh
+++ b/aws/scripts/sh/gh_auth_login.sh
@@ -16,7 +16,6 @@ echo "Retrieving GitHub token for authentication..."
 
 # Configure git to handle CodeBuild environment ownership issues
 git config --global --add safe.directory "${CODEBUILD_SRC_DIR}" 2>/dev/null || true
-git config --global --add safe.directory "*" 2>/dev/null || true
 
 # Get the GitHub token secret ID
 SECRET_ID=$(aws secretsmanager list-secrets --query "SecretList[?starts_with(Name, 'github-token-') && DeletedDate==null].Name" --output text)
@@ -27,20 +26,20 @@ if [ -z "$SECRET_ID" ]; then
     exit 1
   else
     echo "Continuing without GitHub authentication..."
-    return 1
+    exit 1
   fi
 fi
 
 # Retrieve and use the token for GitHub CLI authentication
 if aws secretsmanager get-secret-value --secret-id "$SECRET_ID" --query 'SecretString' --output text | jq -r '.token' | gh auth login --with-token; then
   echo "GitHub authentication successful."
-  return 0
+  exit 0
 else
   echo "GitHub authentication failed."
   if [ "$EXIT_ON_FAILURE" = "true" ]; then
     exit 1
   else
     echo "Continuing without GitHub authentication..."
-    return 1
+    exit 1
   fi
 fi 

--- a/aws/scripts/sh/gh_auth_login.sh
+++ b/aws/scripts/sh/gh_auth_login.sh
@@ -16,7 +16,7 @@ echo "Retrieving GitHub token for authentication..."
 
 # Configure git to handle CodeBuild environment ownership issues
 git config --global --add safe.directory /codebuild/output/srcDownload/src 2>/dev/null || true
-git config --global --add safe.directory ${CODEBUILD_SRC_DIR} 2>/dev/null || true
+git config --global --add safe.directory "${CODEBUILD_SRC_DIR}" 2>/dev/null || true
 git config --global --add safe.directory "*" 2>/dev/null || true
 
 # Get the GitHub token secret ID

--- a/aws/scripts/sh/gh_auth_login.sh
+++ b/aws/scripts/sh/gh_auth_login.sh
@@ -2,7 +2,6 @@
 
 # GitHub Authentication Script
 # This script handles GitHub CLI authentication using AWS Secrets Manager
-# Usage: source gh_auth_login.sh [exit_on_failure]
 
 set -e
 

--- a/aws/scripts/sh/gh_auth_login.sh
+++ b/aws/scripts/sh/gh_auth_login.sh
@@ -15,7 +15,6 @@ EXIT_ON_FAILURE=${1:-true}
 echo "Retrieving GitHub token for authentication..."
 
 # Configure git to handle CodeBuild environment ownership issues
-git config --global --add safe.directory /codebuild/output/srcDownload/src 2>/dev/null || true
 git config --global --add safe.directory "${CODEBUILD_SRC_DIR}" 2>/dev/null || true
 git config --global --add safe.directory "*" 2>/dev/null || true
 
@@ -28,20 +27,20 @@ if [ -z "$SECRET_ID" ]; then
     exit 1
   else
     echo "Continuing without GitHub authentication..."
-    return 1 2>/dev/null || exit 1
+    return 1
   fi
 fi
 
 # Retrieve and use the token for GitHub CLI authentication
 if aws secretsmanager get-secret-value --secret-id "$SECRET_ID" --query 'SecretString' --output text | jq -r '.token' | gh auth login --with-token; then
   echo "GitHub authentication successful."
-  return 0 2>/dev/null || exit 0
+  return 0
 else
   echo "GitHub authentication failed."
   if [ "$EXIT_ON_FAILURE" = "true" ]; then
     exit 1
   else
     echo "Continuing without GitHub authentication..."
-    return 1 2>/dev/null || exit 1
+    return 1
   fi
 fi 


### PR DESCRIPTION
## Description
Added error handling to the CodeBuild deploy.yml to post a comment to the GitHub PR when the sandbox deployment process fails. This ensures frontend developers are notified when a sandbox environment is not created due to build errors.

## Related Issue
Fixes #69 

## Motivation and Context
The lack of feedback in GitHub PRs when sandbox creation fails leads to confusion for developers. By automatically posting a failure comment when the build fails, this change improves developer visibility and accelerates debugging.

## How Has This Been Tested?
Tested by:
    Triggering sandbox creation from a PR
    Inducing failure in the build process (e.g., invalid Dockerfile)
    Verifying that a failure message is posted in the PR
    Ensuring successful builds still work as expected
Tested in AWS CodeBuild environment with GitHub authentication via GitHub CLI and AWS Secrets Manager token integration.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING.md**](https://github.com/VilnaCRM-Org/infrastructure-template/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] You have only one commit (if not, squash them into one commit).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automated failure notifications are posted on GitHub pull requests after sandbox deployment failures, guiding users to review build logs.
  - Enhanced GitHub authentication via a reusable script improves reliability and simplifies the build process.
  - Added environment variable validation to ensure necessary settings are present during health checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->