### PR TITLE
fix(#84): increase build_timeout from 25 to 35 minutes

### DIFF
--- a/terraform/app/modules/aws/codebuild/stages/variables.tf
+++ b/terraform/app/modules/aws/codebuild/stages/variables.tf
@@ -36,5 +36,5 @@ variable "build_projects" {
 variable "build_timeout" {
   description = "Timeout for the CodeBuild project"
   type        = number
-  default     = 25
+  default     = 35
 }


### PR DESCRIPTION
## Description
Increased the build timeout setting for the affected AWS CodeBuild stage from 25 minutes to 35 minutes. This adjustment ensures the build has sufficient time to complete, avoiding premature terminations due to timeout.

## Related Issue
Fixes #84 

## Motivation and Context
Recent builds began exceeding the 25-minute limit and were being terminated before completion. Increasing the timeout to 35 minutes resolves the issue and accommodates the longer build duration needed for new steps or dependencies.

## How Has This Been Tested?
1. Updated the timeoutInMinutes setting in the CodeBuild Terraform configuration.
2. Deployed changes via terraspace up to test infrastructure update.
3. Triggered a test build to ensure that it ran past the 25-minute mark successfully.
4. Verified that the build completed successfully within the new 35-minute limit.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING.md**](https://github.com/VilnaCRM-Org/infrastructure-template/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] You have only one commit (if not, squash them into one commit).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the default build timeout for CI build pipelines from 25 to 35 minutes to reduce premature timeouts and improve build reliability.
  * Enhances stability of longer-running build stages without affecting application features or behavior.
  * No user-facing changes; operational improvement for development and deployment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->