### PR TITLE
fix(#91): resolve aws chatbot lack permissions to start/stop pipeline

### DIFF
--- a/terraform/app/modules/aws/chatbot/main.tf
+++ b/terraform/app/modules/aws/chatbot/main.tf
@@ -27,6 +27,18 @@ data "aws_iam_policy_document" "chatbot_codepipeline_policy" {
       "arn:aws:codepipeline:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:*"
     ]
   }
+
+  statement {
+    sid    = "CodePipelineExecutionControl"
+    effect = "Allow"
+    actions = [
+      "codepipeline:StartPipelineExecution",
+      "codepipeline:StopPipelineExecution"
+    ]
+    resources = [
+      "arn:aws:codepipeline:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:*"
+    ]
+  }
 }
 
 resource "awscc_iam_role" "chatbot_role" {


### PR DESCRIPTION
# Pull Request Template

<!--- Provide a general summary of your changes in the Title above -->

## Description
Updated the codepipeline-chatbot-channel-role IAM policy to include permissions for starting and stopping CodePipeline executions. Added a new policy statement in the chatbot module that grants:
codepipeline:StartPipelineExecution
codepipeline:StopPipelineExecution
This enables Slack users to control pipeline executions via AWS Chatbot buttons/commands.


## Related Issue
Fixes #91 

## Motivation and Context
The Slack chatbot buttons for starting and stopping pipelines were failing with AccessDeniedException. The chatbot IAM role only had read-only CodePipeline permissions, preventing users from executing pipeline control commands from Slack. This blocked the ability to manually trigger or stop pipeline executions (e.g., sandbox-creation pipeline) through the Slack interface, forcing users to use the AWS Console instead.

## How Has This Been Tested?
- Apply Terraform changes: terraform plan and terraform apply in the terraform/ directory
- Verify IAM policy update in AWS Console for codepipeline-chatbot-channel-role
- Test in Slack by clicking "Start Pipeline" button on a CodePipeline notification
- Verify successful pipeline execution start with returned ExecutionId
- Test "Stop Pipeline" functionality on a running pipeline

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING.md**](https://github.com/VilnaCRM-Org/infrastructure-template/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] You have only one commit (if not, squash them into one commit).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure permissions to enable pipeline execution management capabilities for the chatbot service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->