### PR TITLE
fix: reduce test environment baseline AWS costs

### DIFF
--- a/terraform/app/modules/aws/cloudfront/anomaly_detection_alarms.tf
+++ b/terraform/app/modules/aws/cloudfront/anomaly_detection_alarms.tf
@@ -1,4 +1,5 @@
 resource "aws_cloudwatch_metric_alarm" "cloudfront_requests_anomaly_detection" {
+  count               = var.enable_cloudwatch_alarms ? 1 : 0
   provider            = aws.us-east-1
   alarm_name          = "${var.project_name}-cloudfront-requests-anomaly-detection"
   comparison_operator = "LessThanLowerOrGreaterThanUpperThreshold"
@@ -32,6 +33,7 @@ resource "aws_cloudwatch_metric_alarm" "cloudfront_requests_anomaly_detection" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "wafv2_blocked_requests_anomaly_detection" {
+  count               = var.enable_cloudwatch_alarms && var.enable_waf ? 1 : 0
   provider            = aws.us-east-1
   alarm_name          = "${var.project_name}-wafv2-blocked-requests-anomaly-detection"
   comparison_operator = "LessThanLowerOrGreaterThanUpperThreshold"

--- a/terraform/app/modules/aws/cloudfront/cloudwatch.tf
+++ b/terraform/app/modules/aws/cloudfront/cloudwatch.tf
@@ -1,4 +1,5 @@
 resource "aws_cloudwatch_log_group" "waf_web_acl_log_group" {
+  count = var.enable_waf ? 1 : 0
   #checkov:skip=CKV_AWS_338: The one year is too much
   #checkov:skip=CKV_AWS_158: KMS encryption is not needed
   provider          = aws.us-east-1

--- a/terraform/app/modules/aws/cloudfront/data.tf
+++ b/terraform/app/modules/aws/cloudfront/data.tf
@@ -3,6 +3,8 @@ data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 
 data "aws_iam_policy_document" "cloudwatch_alarm_sns_topic_doc" {
+  count = var.enable_cloudwatch_alarms ? 1 : 0
+
   statement {
     sid     = "AllowSNSPublishIntoTopicForCloudWatch"
     effect  = "Allow"
@@ -18,19 +20,7 @@ data "aws_iam_policy_document" "cloudwatch_alarm_sns_topic_doc" {
     condition {
       test     = "ArnLike"
       variable = "aws:SourceArn"
-      values = [
-        "${aws_cloudwatch_metric_alarm.cloudfront_500_errors.arn}",
-        "${aws_cloudwatch_metric_alarm.cloudfront_origin_latency.arn}",
-        "${aws_cloudwatch_metric_alarm.cloudfront_staging_500_errors.arn}",
-        "${aws_cloudwatch_metric_alarm.cloudfront_staging_origin_latency.arn}",
-        "${aws_cloudwatch_metric_alarm.cloudfront_requests_anomaly_detection.arn}",
-        "${aws_cloudwatch_metric_alarm.wafv2_blocked_requests_anomaly_detection.arn}",
-        "${aws_cloudwatch_metric_alarm.wafv2_country_blocked_requests.arn}",
-        "${aws_cloudwatch_metric_alarm.cloudfront_requests_flood_alarm.arn}",
-        "${aws_cloudwatch_metric_alarm.wafv2_high_rate_blocked_requests.arn}",
-        "${aws_cloudwatch_metric_alarm.wafv2_scanning_alarm.arn}",
-        "${aws_cloudwatch_metric_alarm.wafv2_bots_alarm.arn}",
-      ]
+      values   = local.cloudwatch_alarm_source_arns
     }
   }
 }

--- a/terraform/app/modules/aws/cloudfront/locals.tf
+++ b/terraform/app/modules/aws/cloudfront/locals.tf
@@ -15,4 +15,18 @@ locals {
     "minimum_protocol_version",
     "TLSv1.2_2021"
   )
+
+  cloudwatch_alarm_source_arns = concat(
+    aws_cloudwatch_metric_alarm.cloudfront_500_errors[*].arn,
+    aws_cloudwatch_metric_alarm.cloudfront_origin_latency[*].arn,
+    aws_cloudwatch_metric_alarm.cloudfront_staging_500_errors[*].arn,
+    aws_cloudwatch_metric_alarm.cloudfront_staging_origin_latency[*].arn,
+    aws_cloudwatch_metric_alarm.cloudfront_requests_anomaly_detection[*].arn,
+    aws_cloudwatch_metric_alarm.wafv2_blocked_requests_anomaly_detection[*].arn,
+    aws_cloudwatch_metric_alarm.wafv2_country_blocked_requests[*].arn,
+    aws_cloudwatch_metric_alarm.cloudfront_requests_flood_alarm[*].arn,
+    aws_cloudwatch_metric_alarm.wafv2_high_rate_blocked_requests[*].arn,
+    aws_cloudwatch_metric_alarm.wafv2_scanning_alarm[*].arn,
+    aws_cloudwatch_metric_alarm.wafv2_bots_alarm[*].arn,
+  )
 }

--- a/terraform/app/modules/aws/cloudfront/main.tf
+++ b/terraform/app/modules/aws/cloudfront/main.tf
@@ -30,7 +30,7 @@ resource "aws_cloudfront_distribution" "this" {
     origin_access_control_id = aws_cloudfront_origin_access_control.replication.id
   }
 
-  web_acl_id = aws_wafv2_web_acl.waf_web_acl.arn
+  web_acl_id = var.enable_waf ? aws_wafv2_web_acl.waf_web_acl[0].arn : null
 
   aliases = [
     var.domain_name,
@@ -143,7 +143,7 @@ resource "aws_cloudfront_distribution" "staging_cloudfront_distribution" {
     origin_access_control_id = aws_cloudfront_origin_access_control.replication.id
   }
 
-  web_acl_id = aws_wafv2_web_acl.waf_web_acl.arn
+  web_acl_id = var.enable_waf ? aws_wafv2_web_acl.waf_web_acl[0].arn : null
 
 
   is_ipv6_enabled     = true

--- a/terraform/app/modules/aws/cloudfront/outputs.tf
+++ b/terraform/app/modules/aws/cloudfront/outputs.tf
@@ -24,12 +24,12 @@ output "cloudwatch_sns_topic_arn" {
 }
 
 output "waf_web_acl_name" {
-  value       = aws_wafv2_web_acl.waf_web_acl.name
+  value       = var.enable_waf ? aws_wafv2_web_acl.waf_web_acl[0].name : ""
   description = "Name of the WAF2 Web ACL Of Distribution"
 }
 
 output "waf_log_group_name" {
-  value       = aws_cloudwatch_log_group.waf_web_acl_log_group.name
+  value       = var.enable_waf ? aws_cloudwatch_log_group.waf_web_acl_log_group[0].name : ""
   description = "Name of the WAF2 Log Group"
 }
 

--- a/terraform/app/modules/aws/cloudfront/sns.tf
+++ b/terraform/app/modules/aws/cloudfront/sns.tf
@@ -7,10 +7,10 @@ resource "aws_sns_topic" "cloudwatch_alarm_notifications" {
 }
 
 resource "aws_sns_topic_policy" "cloudwatch_alarm_notifications" {
+  count    = var.enable_cloudwatch_alarms ? 1 : 0
   provider = aws.us-east-1
   arn      = aws_sns_topic.cloudwatch_alarm_notifications.arn
-  policy   = data.aws_iam_policy_document.cloudwatch_alarm_sns_topic_doc.json
+  policy   = data.aws_iam_policy_document.cloudwatch_alarm_sns_topic_doc[0].json
 
   depends_on = [aws_sns_topic.cloudwatch_alarm_notifications]
 }
-

--- a/terraform/app/modules/aws/cloudfront/static_alarms.tf
+++ b/terraform/app/modules/aws/cloudfront/static_alarms.tf
@@ -1,4 +1,5 @@
 resource "aws_cloudwatch_metric_alarm" "cloudfront_500_errors" {
+  count               = var.enable_cloudwatch_alarms ? 1 : 0
   provider            = aws.us-east-1
   alarm_name          = "${var.project_name}-cloudfront-5xx-errors-alarm"
   comparison_operator = "GreaterThanThreshold"
@@ -19,6 +20,7 @@ resource "aws_cloudwatch_metric_alarm" "cloudfront_500_errors" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "cloudfront_origin_latency" {
+  count               = var.enable_cloudwatch_alarms ? 1 : 0
   provider            = aws.us-east-1
   alarm_name          = "${var.project_name}-cloudfront-origin-latency-alarm"
   comparison_operator = "GreaterThanThreshold"
@@ -39,6 +41,7 @@ resource "aws_cloudwatch_metric_alarm" "cloudfront_origin_latency" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "wafv2_country_blocked_requests" {
+  count               = var.enable_cloudwatch_alarms && var.enable_waf ? 1 : 0
   provider            = aws.us-east-1
   alarm_name          = "${var.project_name}-wafv2-country-blocked-requests"
   comparison_operator = "GreaterThanThreshold"
@@ -58,6 +61,7 @@ resource "aws_cloudwatch_metric_alarm" "wafv2_country_blocked_requests" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "wafv2_high_rate_blocked_requests" {
+  count               = var.enable_cloudwatch_alarms && var.enable_waf ? 1 : 0
   provider            = aws.us-east-1
   alarm_name          = "${var.project_name}-wafv2-high-rate-blocked-requests"
   comparison_operator = "GreaterThanThreshold"
@@ -76,6 +80,7 @@ resource "aws_cloudwatch_metric_alarm" "wafv2_high_rate_blocked_requests" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "wafv2_scanning_alarm" {
+  count               = var.enable_cloudwatch_alarms && var.enable_waf ? 1 : 0
   provider            = aws.us-east-1
   alarm_name          = "${var.project_name}-wafv2-scanning-alarm"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -96,6 +101,7 @@ resource "aws_cloudwatch_metric_alarm" "wafv2_scanning_alarm" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "wafv2_bots_alarm" {
+  count               = var.enable_cloudwatch_alarms && var.enable_waf ? 1 : 0
   provider            = aws.us-east-1
   alarm_name          = "${var.project_name}-wafv2-bots-alarm"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -145,6 +151,7 @@ resource "aws_cloudwatch_metric_alarm" "wafv2_bots_alarm" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "cloudfront_requests_flood_alarm" {
+  count               = var.enable_cloudwatch_alarms ? 1 : 0
   provider            = aws.us-east-1
   alarm_name          = "${var.project_name}-cloudfront-requests-flood-alarm"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -165,6 +172,7 @@ resource "aws_cloudwatch_metric_alarm" "cloudfront_requests_flood_alarm" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "cloudfront_staging_500_errors" {
+  count               = var.enable_cloudwatch_alarms ? 1 : 0
   provider            = aws.us-east-1
   alarm_name          = "${var.project_name}-cloudfront-staging-5xx-errors-alarm"
   comparison_operator = "GreaterThanThreshold"
@@ -185,6 +193,7 @@ resource "aws_cloudwatch_metric_alarm" "cloudfront_staging_500_errors" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "cloudfront_staging_origin_latency" {
+  count               = var.enable_cloudwatch_alarms ? 1 : 0
   provider            = aws.us-east-1
   alarm_name          = "${var.project_name}-cloudfront-staging-origin-latency-alarm"
   comparison_operator = "GreaterThanThreshold"

--- a/terraform/app/modules/aws/cloudfront/variables.tf
+++ b/terraform/app/modules/aws/cloudfront/variables.tf
@@ -47,6 +47,16 @@ variable "enable_cloudfront_staging" {
   type        = bool
 }
 
+variable "enable_cloudwatch_alarms" {
+  description = "Whether to create CloudWatch alarms for CloudFront and WAF"
+  type        = bool
+}
+
+variable "enable_waf" {
+  description = "Whether to create and attach the WAF web ACL"
+  type        = bool
+}
+
 variable "cloudfront_configuration" {
   type        = map(any)
   description = "CloudFront Configuration"

--- a/terraform/app/modules/aws/cloudfront/wafv2.tf
+++ b/terraform/app/modules/aws/cloudfront/wafv2.tf
@@ -1,4 +1,5 @@
 resource "aws_wafv2_web_acl" "waf_web_acl" {
+  count    = var.enable_waf ? 1 : 0
   provider = aws.us-east-1
   name     = "wafv2-web-acl"
   scope    = "CLOUDFRONT"
@@ -116,9 +117,10 @@ resource "aws_wafv2_web_acl" "waf_web_acl" {
 }
 
 resource "aws_wafv2_web_acl_logging_configuration" "waf_web_acl_logging" {
+  count                   = var.enable_waf ? 1 : 0
   provider                = aws.us-east-1
-  log_destination_configs = [aws_cloudwatch_log_group.waf_web_acl_log_group.arn]
-  resource_arn            = aws_wafv2_web_acl.waf_web_acl.arn
+  log_destination_configs = [aws_cloudwatch_log_group.waf_web_acl_log_group[0].arn]
+  resource_arn            = aws_wafv2_web_acl.waf_web_acl[0].arn
   depends_on = [
     aws_wafv2_web_acl.waf_web_acl,
     aws_cloudwatch_log_group.waf_web_acl_log_group

--- a/terraform/app/modules/aws/cloudwatch/dynamodb/alarms.tf
+++ b/terraform/app/modules/aws/cloudwatch/dynamodb/alarms.tf
@@ -1,4 +1,5 @@
 resource "aws_cloudwatch_metric_alarm" "dynamodb_read_capacity_anomaly_detection" {
+  count               = var.enable_cloudwatch_alarms ? 1 : 0
   alarm_name          = "${var.project_name}-dynamodb-read-capacity-anomaly-detection"
   comparison_operator = "LessThanLowerOrGreaterThanUpperThreshold"
   evaluation_periods  = 5
@@ -30,6 +31,7 @@ resource "aws_cloudwatch_metric_alarm" "dynamodb_read_capacity_anomaly_detection
 }
 
 resource "aws_cloudwatch_metric_alarm" "dynamodb_write_capacity_anomaly_detection" {
+  count               = var.enable_cloudwatch_alarms ? 1 : 0
   alarm_name          = "${var.project_name}-dynamodb-write-capacity-anomaly-detection"
   comparison_operator = "LessThanLowerOrGreaterThanUpperThreshold"
   evaluation_periods  = 5
@@ -61,6 +63,7 @@ resource "aws_cloudwatch_metric_alarm" "dynamodb_write_capacity_anomaly_detectio
 }
 
 resource "aws_cloudwatch_metric_alarm" "dynamodb_system_errors_detection" {
+  count               = var.enable_cloudwatch_alarms ? 1 : 0
   alarm_name          = "${var.project_name}-dynamodb-system-errors"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 1

--- a/terraform/app/modules/aws/cloudwatch/dynamodb/outputs.tf
+++ b/terraform/app/modules/aws/cloudwatch/dynamodb/outputs.tf
@@ -1,7 +1,7 @@
 output "cloudwatch_alarms_arns" {
-  value = [
-    aws_cloudwatch_metric_alarm.dynamodb_write_capacity_anomaly_detection.arn,
-    aws_cloudwatch_metric_alarm.dynamodb_read_capacity_anomaly_detection.arn,
-    aws_cloudwatch_metric_alarm.dynamodb_system_errors_detection.arn,
-  ]
+  value = concat(
+    aws_cloudwatch_metric_alarm.dynamodb_write_capacity_anomaly_detection[*].arn,
+    aws_cloudwatch_metric_alarm.dynamodb_read_capacity_anomaly_detection[*].arn,
+    aws_cloudwatch_metric_alarm.dynamodb_system_errors_detection[*].arn,
+  )
 }

--- a/terraform/app/modules/aws/cloudwatch/dynamodb/variables.tf
+++ b/terraform/app/modules/aws/cloudwatch/dynamodb/variables.tf
@@ -28,6 +28,11 @@ variable "cloudwatch_alerts_sns_topic_arn" {
   type        = string
 }
 
+variable "enable_cloudwatch_alarms" {
+  description = "Whether to create CloudWatch alarms for DynamoDB logging"
+  type        = bool
+}
+
 variable "tags" {
   description = "Tags to be attached to the CodePipeline"
   type        = map(any)

--- a/terraform/app/modules/aws/codepipeline/website/cloudwatch.tf
+++ b/terraform/app/modules/aws/codepipeline/website/cloudwatch.tf
@@ -7,6 +7,7 @@ resource "aws_cloudwatch_log_group" "reports_notification_group" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "lambda_invocations_anomaly_detection" {
+  count               = var.enable_cloudwatch_alarms ? 1 : 0
   alarm_name          = "${var.project_name}-lambda-reports-invocations-anomaly-detection"
   comparison_operator = "GreaterThanUpperThreshold"
   evaluation_periods  = 1
@@ -39,6 +40,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_invocations_anomaly_detection" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "lambda_errors_detection" {
+  count               = var.enable_cloudwatch_alarms ? 1 : 0
   alarm_name          = "${var.project_name}-lambda-reports-errors"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 1
@@ -56,6 +58,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_errors_detection" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "lambda_throttles_anomaly_detection" {
+  count               = var.enable_cloudwatch_alarms ? 1 : 0
   alarm_name          = "${var.project_name}-lambda-reports-throttles-anomaly-detection"
   comparison_operator = "GreaterThanUpperThreshold"
   evaluation_periods  = 1
@@ -88,6 +91,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_throttles_anomaly_detection" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "lambda_duration_anomaly_detection" {
+  count               = var.enable_cloudwatch_alarms ? 1 : 0
   alarm_name          = "${var.project_name}-lambda-reports-duration-anomaly-detection"
   comparison_operator = "GreaterThanUpperThreshold"
   evaluation_periods  = 1

--- a/terraform/app/modules/aws/codepipeline/website/outputs.tf
+++ b/terraform/app/modules/aws/codepipeline/website/outputs.tf
@@ -24,10 +24,10 @@ output "reports_sns_topic_arn" {
 }
 
 output "cloudwatch_alarms_arns" {
-  value = [
-    aws_cloudwatch_metric_alarm.lambda_invocations_anomaly_detection.arn,
-    aws_cloudwatch_metric_alarm.lambda_errors_detection.arn,
-    aws_cloudwatch_metric_alarm.lambda_throttles_anomaly_detection.arn,
-    aws_cloudwatch_metric_alarm.lambda_duration_anomaly_detection.arn,
-  ]
+  value = concat(
+    aws_cloudwatch_metric_alarm.lambda_invocations_anomaly_detection[*].arn,
+    aws_cloudwatch_metric_alarm.lambda_errors_detection[*].arn,
+    aws_cloudwatch_metric_alarm.lambda_throttles_anomaly_detection[*].arn,
+    aws_cloudwatch_metric_alarm.lambda_duration_anomaly_detection[*].arn,
+  )
 }

--- a/terraform/app/modules/aws/codepipeline/website/variables.tf
+++ b/terraform/app/modules/aws/codepipeline/website/variables.tf
@@ -91,3 +91,8 @@ variable "cloudwatch_log_group_retention_days" {
   description = "Retention time of Cloudwatch log group logs"
   type        = number
 }
+
+variable "enable_cloudwatch_alarms" {
+  description = "Whether to create CloudWatch alarms for the website pipeline"
+  type        = bool
+}

--- a/terraform/app/modules/aws/s3/canary-reports/main.tf
+++ b/terraform/app/modules/aws/s3/canary-reports/main.tf
@@ -55,6 +55,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "canaries_reports_bucket_lifecy
       days = var.s3_artifacts_bucket_files_deletion_days
     }
 
+    noncurrent_version_expiration {
+      noncurrent_days = var.s3_artifacts_bucket_files_deletion_days
+    }
+
     status = "Enabled"
   }
 }

--- a/terraform/app/modules/aws/s3/codepipeline/main.tf
+++ b/terraform/app/modules/aws/s3/codepipeline/main.tf
@@ -63,6 +63,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "codepipeline_bucket_lifecycle_
       days = var.s3_artifacts_bucket_files_deletion_days
     }
 
+    noncurrent_version_expiration {
+      noncurrent_days = var.s3_artifacts_bucket_files_deletion_days
+    }
+
     status = "Enabled"
   }
 }

--- a/terraform/app/modules/aws/s3/infrastructure-logging/main.tf
+++ b/terraform/app/modules/aws/s3/infrastructure-logging/main.tf
@@ -45,6 +45,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "logging_bucket_lifecycle_confi
       days = var.s3_logs_lifecycle_configuration.deletion_days
     }
 
+    noncurrent_version_expiration {
+      noncurrent_days = var.s3_logs_lifecycle_configuration.deletion_days
+    }
+
     transition {
       days          = var.s3_logs_lifecycle_configuration.standard_ia_transition_days
       storage_class = "STANDARD_IA"

--- a/terraform/app/modules/aws/s3/public/main.tf
+++ b/terraform/app/modules/aws/s3/public/main.tf
@@ -83,6 +83,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "bucket_lifecycle_configuration
       days = var.s3_artifacts_bucket_files_deletion_days
     }
 
+    noncurrent_version_expiration {
+      noncurrent_days = var.s3_artifacts_bucket_files_deletion_days
+    }
+
     status = "Enabled"
   }
 }

--- a/terraform/app/modules/aws/s3/website-logging/main.tf
+++ b/terraform/app/modules/aws/s3/website-logging/main.tf
@@ -60,6 +60,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "logging_bucket_lifecycle_confi
       days = var.s3_logs_lifecycle_configuration.deletion_days
     }
 
+    noncurrent_version_expiration {
+      noncurrent_days = var.s3_logs_lifecycle_configuration.deletion_days
+    }
+
     transition {
       days          = var.s3_logs_lifecycle_configuration.standard_ia_transition_days
       storage_class = "STANDARD_IA"

--- a/terraform/app/modules/aws/s3/website-logging/replication-logging.tf
+++ b/terraform/app/modules/aws/s3/website-logging/replication-logging.tf
@@ -67,6 +67,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "replication_logging_bucket_lif
       days = var.s3_logs_lifecycle_configuration.deletion_days
     }
 
+    noncurrent_version_expiration {
+      noncurrent_days = var.s3_logs_lifecycle_configuration.deletion_days
+    }
+
     transition {
       days          = var.s3_logs_lifecycle_configuration.standard_ia_transition_days
       storage_class = "STANDARD_IA"

--- a/terraform/app/modules/aws/s3/website/cloudwatch.tf
+++ b/terraform/app/modules/aws/s3/website/cloudwatch.tf
@@ -6,7 +6,7 @@ resource "aws_cloudwatch_log_group" "s3_lambda_notification_group" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "s3_objects_anomaly_detection" {
-  count               = var.staging ? 0 : 1
+  count               = var.enable_cloudwatch_alarms && !var.staging ? 1 : 0
   alarm_name          = "${var.project_name}-s3-objects-anomaly-detection"
   comparison_operator = "LessThanLowerOrGreaterThanUpperThreshold"
   evaluation_periods  = 5
@@ -39,7 +39,7 @@ resource "aws_cloudwatch_metric_alarm" "s3_objects_anomaly_detection" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "s3_requests_anomaly_detection" {
-  count               = var.staging ? 0 : 1
+  count               = var.enable_cloudwatch_alarms && !var.staging ? 1 : 0
   alarm_name          = "${var.project_name}-s3-requests-anomaly-detection"
   comparison_operator = "LessThanLowerOrGreaterThanUpperThreshold"
   evaluation_periods  = 5
@@ -73,6 +73,7 @@ resource "aws_cloudwatch_metric_alarm" "s3_requests_anomaly_detection" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "s3_4xx_errors_anomaly_detection" {
+  count               = var.enable_cloudwatch_alarms ? 1 : 0
   alarm_name          = "${var.project_name}-s3-4xx-errors-anomaly-detection"
   comparison_operator = "GreaterThanUpperThreshold"
   evaluation_periods  = 1
@@ -107,7 +108,7 @@ resource "aws_cloudwatch_metric_alarm" "s3_4xx_errors_anomaly_detection" {
 
 
 resource "aws_cloudwatch_metric_alarm" "lambda_invocations_anomaly_detection" {
-  count               = var.staging ? 0 : 1
+  count               = var.enable_cloudwatch_alarms && !var.staging ? 1 : 0
   alarm_name          = "${var.project_name}-lambda-s3-invocations-anomaly-detection"
   comparison_operator = "GreaterThanUpperThreshold"
   evaluation_periods  = 1
@@ -140,7 +141,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_invocations_anomaly_detection" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "lambda_errors_detection" {
-  count               = var.staging ? 0 : 1
+  count               = var.enable_cloudwatch_alarms && !var.staging ? 1 : 0
   alarm_name          = "${var.project_name}-lambda-s3-errors-detection"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 1
@@ -160,7 +161,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_errors_detection" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "lambda_throttles_anomaly_detection" {
-  count               = var.staging ? 0 : 1
+  count               = var.enable_cloudwatch_alarms && !var.staging ? 1 : 0
   alarm_name          = "${var.project_name}-lambda-s3-throttles-anomaly-detection"
   comparison_operator = "GreaterThanUpperThreshold"
   evaluation_periods  = 1
@@ -193,7 +194,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_throttles_anomaly_detection" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "lambda_duration_anomaly_detection" {
-  count               = var.staging ? 0 : 1
+  count               = var.enable_cloudwatch_alarms && !var.staging ? 1 : 0
   alarm_name          = "${var.project_name}-lambda-s3-duration-anomaly-detection"
   comparison_operator = "GreaterThanUpperThreshold"
   evaluation_periods  = 1

--- a/terraform/app/modules/aws/s3/website/data_sns.tf
+++ b/terraform/app/modules/aws/s3/website/data_sns.tf
@@ -16,22 +16,26 @@ data "aws_iam_policy_document" "sns_bucket_topic_doc" {
     }
   }
 
-  statement {
-    sid     = "AllowSNSPublishIntoTopicForCloudWatch"
-    effect  = "Allow"
-    actions = ["sns:Publish"]
+  dynamic "statement" {
+    for_each = var.enable_cloudwatch_alarms ? [1] : []
 
-    principals {
-      type        = "Service"
-      identifiers = ["cloudwatch.amazonaws.com"]
-    }
+    content {
+      sid     = "AllowSNSPublishIntoTopicForCloudWatch"
+      effect  = "Allow"
+      actions = ["sns:Publish"]
 
-    resources = ["${aws_sns_topic.bucket_notifications.arn}"]
+      principals {
+        type        = "Service"
+        identifiers = ["cloudwatch.amazonaws.com"]
+      }
 
-    condition {
-      test     = "ArnLike"
-      variable = "aws:SourceArn"
-      values   = var.staging == true ? local.sns_staging_alarms : local.sns_alarms
+      resources = ["${aws_sns_topic.bucket_notifications.arn}"]
+
+      condition {
+        test     = "ArnLike"
+        variable = "aws:SourceArn"
+        values   = var.staging == true ? local.sns_staging_alarms : local.sns_alarms
+      }
     }
   }
 }

--- a/terraform/app/modules/aws/s3/website/locals.tf
+++ b/terraform/app/modules/aws/s3/website/locals.tf
@@ -3,9 +3,9 @@ locals {
   allow_force_destroy                   = var.environment == "test" ? true : false
   lambda_s3_notifications_function_name = "${var.project_name}-website-infra-s3-notifications"
 
-  sns_staging_alarms = ["arn:aws:cloudwatch:${var.region}:${local.account_id}:alarm:${var.project_name}-s3-4xx-errors-anomaly-detection", ]
+  sns_staging_alarms = var.enable_cloudwatch_alarms ? ["arn:aws:cloudwatch:${var.region}:${local.account_id}:alarm:${var.project_name}-s3-4xx-errors-anomaly-detection"] : []
 
-  sns_alarms = [
+  sns_alarms = var.enable_cloudwatch_alarms ? [
     "arn:aws:cloudwatch:${var.region}:${local.account_id}:alarm:${var.project_name}-s3-objects-anomaly-detection",
     "arn:aws:cloudwatch:${var.region}:${local.account_id}:alarm:${var.project_name}-s3-requests-anomaly-detection",
     "arn:aws:cloudwatch:${var.region}:${local.account_id}:alarm:${var.project_name}-s3-4xx-errors-anomaly-detection",
@@ -13,6 +13,6 @@ locals {
     "arn:aws:cloudwatch:${var.region}:${local.account_id}:alarm:${var.project_name}-lambda-s3-errors-detection",
     "arn:aws:cloudwatch:${var.region}:${local.account_id}:alarm:${var.project_name}-lambda-s3-throttles-anomaly-detection",
     "arn:aws:cloudwatch:${var.region}:${local.account_id}:alarm:${var.project_name}-lambda-s3-duration-anomaly-detection",
-  ]
+  ] : []
 
 }

--- a/terraform/app/modules/aws/s3/website/variables.tf
+++ b/terraform/app/modules/aws/s3/website/variables.tf
@@ -60,6 +60,11 @@ variable "cloudwatch_log_group_retention_days" {
   type        = number
 }
 
+variable "enable_cloudwatch_alarms" {
+  description = "Whether to create CloudWatch alarms for the website bucket"
+  type        = bool
+}
+
 variable "staging" {
   type        = string
   description = "Domain name for website, used for all resources"

--- a/terraform/app/stacks/ci-cd-infrastructure/ci_cd_website.tf
+++ b/terraform/app/stacks/ci-cd-infrastructure/ci_cd_website.tf
@@ -69,6 +69,7 @@ module "ci_cd_website_codepipeline" {
   lambda_python_version                 = var.lambda_python_version
   lambda_reserved_concurrent_executions = var.lambda_reserved_concurrent_executions
   cloudwatch_log_group_retention_days   = var.cloudwatch_log_group_retention_days
+  enable_cloudwatch_alarms              = var.enable_cloudwatch_alarms
 
   stages = var.ci_cd_website_stage_input
 

--- a/terraform/app/stacks/ci-cd-infrastructure/logging.tf
+++ b/terraform/app/stacks/ci-cd-infrastructure/logging.tf
@@ -22,6 +22,7 @@ module "dynamodb_logging" {
   logging_bucket_id = module.infrastructure_logging_bucket.id
 
   cloudwatch_alerts_sns_topic_arn = module.cloudwatch_alerts_sns.cloudwatch_alerts_sns_topic_arn
+  enable_cloudwatch_alarms        = var.enable_cloudwatch_alarms
 
   tags = var.tags
 

--- a/terraform/app/stacks/ci-cd-infrastructure/tfvars/base.tfvars
+++ b/terraform/app/stacks/ci-cd-infrastructure/tfvars/base.tfvars
@@ -22,6 +22,7 @@ s3_artifacts_bucket_files_deletion_days = 7
 cloudwatch_log_group_retention_days = 7
 
 create_slack_notification = true
+enable_cloudwatch_alarms  = true
 
 runtime_versions = {
   ruby   = "3.2"

--- a/terraform/app/stacks/ci-cd-infrastructure/tfvars/test.tfvars
+++ b/terraform/app/stacks/ci-cd-infrastructure/tfvars/test.tfvars
@@ -15,6 +15,17 @@ tags = {
   Environment = "test"
 }
 
+s3_artifacts_bucket_files_deletion_days = 2
+
+s3_logs_lifecycle_configuration = {
+  standard_ia_transition_days  = 7
+  glacier_transition_days      = 14
+  deep_archive_transition_days = 30
+  deletion_days                = 30
+}
+
+enable_cloudwatch_alarms = false
+
 ci_cd_infra_stage_input = [
   { name = "validate", category = "Test", owner = "AWS", provider = "CodeBuild", input_artifacts = "SourceOutput", output_artifacts = "ValidateOutput" },
   { name = "plan", category = "Test", owner = "AWS", provider = "CodeBuild", input_artifacts = "ValidateOutput", output_artifacts = "PlanOutput" },

--- a/terraform/app/stacks/ci-cd-infrastructure/variables.tf
+++ b/terraform/app/stacks/ci-cd-infrastructure/variables.tf
@@ -169,6 +169,11 @@ variable "cloudwatch_log_group_retention_days" {
   type        = number
 }
 
+variable "enable_cloudwatch_alarms" {
+  description = "Whether to create CloudWatch alarms for CI/CD resources"
+  type        = bool
+}
+
 variable "lambda_python_version" {
   description = "Python version for Lambda"
   type        = string

--- a/terraform/app/stacks/website/cloudfront.tf
+++ b/terraform/app/stacks/website/cloudfront.tf
@@ -17,6 +17,8 @@ module "cloudfront" {
   cloudfront_custom_error_responses = var.cloudfront_custom_error_responses
 
   enable_cloudfront_staging = var.enable_cloudfront_staging
+  enable_cloudwatch_alarms  = var.enable_cloudwatch_alarms
+  enable_waf                = var.enable_waf
 
   tags = var.tags
 }

--- a/terraform/app/stacks/website/dashboard.tf
+++ b/terraform/app/stacks/website/dashboard.tf
@@ -1,4 +1,5 @@
 module "website_dashboard" {
+  count  = var.enable_waf ? 1 : 0
   source = "../../modules/aws/cloudwatch/website-dashboard"
 
   project_name = var.project_name

--- a/terraform/app/stacks/website/s3.tf
+++ b/terraform/app/stacks/website/s3.tf
@@ -12,6 +12,7 @@ module "s3_bucket" {
 
   lambda_configuration                = var.lambda_configuration
   cloudwatch_log_group_retention_days = var.cloudwatch_log_group_retention_days
+  enable_cloudwatch_alarms            = var.enable_cloudwatch_alarms
 
   s3_bucket_custom_name = var.s3_bucket_custom_name
 
@@ -38,6 +39,7 @@ module "staging_s3_bucket" {
 
   lambda_configuration                = var.lambda_configuration
   cloudwatch_log_group_retention_days = var.cloudwatch_log_group_retention_days
+  enable_cloudwatch_alarms            = var.enable_cloudwatch_alarms
 
   s3_bucket_custom_name = "staging.${var.s3_bucket_custom_name}"
 

--- a/terraform/app/stacks/website/tfvars/base.tfvars
+++ b/terraform/app/stacks/website/tfvars/base.tfvars
@@ -28,3 +28,5 @@ lambda_configuration = {
 create_slack_notification = true
 
 enable_cloudfront_staging = true
+enable_cloudwatch_alarms  = true
+enable_waf                = true

--- a/terraform/app/stacks/website/tfvars/test.tfvars
+++ b/terraform/app/stacks/website/tfvars/test.tfvars
@@ -34,3 +34,15 @@ cloudfront_configuration = {
 
 ttl_validation     = 60
 ttl_route53_record = 300
+
+s3_artifacts_bucket_files_deletion_days = 2
+
+s3_logs_lifecycle_configuration = {
+  standard_ia_transition_days  = 7
+  glacier_transition_days      = 14
+  deep_archive_transition_days = 30
+  deletion_days                = 30
+}
+
+enable_cloudwatch_alarms = false
+enable_waf               = false

--- a/terraform/app/stacks/website/variables.tf
+++ b/terraform/app/stacks/website/variables.tf
@@ -93,6 +93,16 @@ variable "enable_cloudfront_staging" {
   type        = bool
 }
 
+variable "enable_cloudwatch_alarms" {
+  description = "Whether to create CloudWatch alarms for website resources"
+  type        = bool
+}
+
+variable "enable_waf" {
+  description = "Whether to create and attach the website WAF web ACL"
+  type        = bool
+}
+
 variable "create_slack_notification" {
   description = "This responsible for creating Slack Notifications"
   type        = bool
@@ -102,4 +112,3 @@ variable "tags" {
   description = "Tags to be associated with the S3 bucket"
   type        = map(any)
 }
-


### PR DESCRIPTION
## Description
Reduce recurring AWS spend in the VilnaCRM test account by pruning stale artifact/log object versions and disabling low-value baseline protections in test.

## Related Issue
- Closes #100

## Motivation and Context
The test account is spending about `$76/month`, with the biggest repo-controlled drivers coming from S3 storage, WAF, and CloudWatch. The main waste pattern is long-lived artifact buckets with retained noncurrent versions, plus fixed monthly WAF/alarm costs that are justified in prod but not in test.

This PR addresses those costs by:
- expiring noncurrent versions in versioned S3 buckets
- reducing test artifact retention from 7 days to 2 days
- shortening test log retention
- adding environment toggles so test disables WAF and non-essential CloudWatch alarms

## How Has This Been Tested?
- `docker run --rm --entrypoint sh -v /tmp/website-infra-cost:/work -w /work/terraform/app/stacks/website hashicorp/terraform:1.14.3 -lc "terraform init -backend=false && terraform validate"`
- `docker run --rm --entrypoint sh -v /tmp/website-infra-cost:/work -w /work/terraform/app/stacks/ci-cd-infrastructure hashicorp/terraform:1.14.3 -lc "terraform init -backend=false && terraform validate"`
- Verified Cost Explorer totals for the VilnaCRM test account (`2026-02-01` to `2026-03-01`) and current artifact bucket sizes before scoping the changes.

## Screenshots (if appropriate)
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING.md**](https://github.com/VilnaCRM-Org/infrastructure-template/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] You have only one commit (if not, squash them into one commit).
