### PR TITLE
fix: unblock prod CI/CD infra validate for website CloudFront TLS setting

### DIFF
--- a/terraform/app/modules/aws/cloudfront/main.tf
+++ b/terraform/app/modules/aws/cloudfront/main.tf
@@ -1,5 +1,6 @@
 resource "aws_cloudfront_distribution" "this" {
   #checkov:skip=CKV2_AWS_47: Log4j protection already included in AWSManagedRulesKnownBadInputsRuleSet
+  #checkov:skip=CKV_AWS_174: Prod/staging continuous deployment still relies on TLSv1.2_2019 until the staged CloudFront rollout is migrated safely.
   provider = aws.us-east-1
   enabled  = true
   origin_group {
@@ -107,6 +108,7 @@ resource "aws_cloudfront_distribution" "this" {
 
 resource "aws_cloudfront_distribution" "staging_cloudfront_distribution" {
   #checkov:skip=CKV2_AWS_47: Log4j protection already included in AWSManagedRulesKnownBadInputsRuleSet
+  #checkov:skip=CKV_AWS_174: Prod/staging continuous deployment still relies on TLSv1.2_2019 until the staged CloudFront rollout is migrated safely.
   provider = aws.us-east-1
   count    = var.enable_cloudfront_staging ? 1 : 0
   staging  = true


### PR DESCRIPTION
## Description
Add a targeted Checkov exception for the two CloudFront distributions in the website module so the shared prod CI/CD validation pipeline can pass without changing the currently required `TLSv1.2_2019` rollout setting.

## Related Issue
Closes #112

## Motivation and Context
`ci-cd-infra-prod-pipeline` is currently failing on `main` during `validate` because Checkov `CKV_AWS_174` rejects the website CloudFront distributions' current minimum protocol version. The lower protocol floor is intentionally still in place while CloudFront continuous deployment/staging remains enabled; the repo already documents that raising it caused `IllegalUpdate` during the earlier rollout.

This fix unblocks the shared infra prod apply so the live `ci-cd-website-prod-pipeline` can be reconciled back to the repo-configured `main` source branch and then rerun cleanly.

## How Has This Been Tested?
- Reproduced the prod failure in AWS:
  - `ci-cd-infra-prod-pipeline` execution `fa847a8b-268f-4b64-89e8-c7e2972f1249`
  - `ci-cd-infra-prod-validate:3e284102-6cc4-490e-ba59-509e5582b84d`
- Traced the failure to Checkov `CKV_AWS_174` on:
  - `module.cloudfront.aws_cloudfront_distribution.this`
  - `module.cloudfront.aws_cloudfront_distribution.staging_cloudfront_distribution`
- Verified the change is scoped to Checkov annotations only.
- Verified `git diff --check` passes.

## Screenshots (if appropriate)
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING.md**](https://github.com/VilnaCRM-Org/infrastructure-template/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] You have only one commit (if not, squash them into one commit).
