### PR TITLE
fix: install bash for website load test batches

### DIFF
--- a/aws/scripts/sh/install_packages.sh
+++ b/aws/scripts/sh/install_packages.sh
@@ -9,6 +9,7 @@ echo "#### Installing Required Packages"
 
 # Install required packages using apk
 apk add --no-cache \
+    bash \
     git \
     curl \
     nodejs \
@@ -22,4 +23,4 @@ apk add --no-cache \
         exit 1
     }
 
-echo "✅ All required packages installed successfully" 
+echo "✅ All required packages installed successfully"


### PR DESCRIPTION
# Pull Request Template

## Description
Install `bash` in the shared Alpine package bootstrap used by website batch CodeBuild jobs. This fixes prod `batch-pw-load` failures where the load-test setup invokes `bash aws/scripts/sh/normalize_load_test_dockerfile.sh`.

## Related Issue
- Closes #114

## Motivation and Context
Prod website deployments are currently blocked because the `loadTests` child build fails in `INSTALL` with `/codebuild/output/tmp/script.sh: line 6: bash: not found`.

## How Has This Been Tested?
- `git diff --check`
- AWS prod failure confirmed from CloudWatch logs for `ci-cd-website-prod-batch-pw-load:561b39be-799e-45bb-ae14-6eca47583a00`
- Verified the fix adds the missing runtime dependency used by the failing command

## Screenshots (if appropriate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING.md**](https://github.com/VilnaCRM-Org/infrastructure-template/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] You have only one commit (if not, squash them into one commit).