### PR TITLE
fix: delete legacy website sandboxes

### DIFF
--- a/aws/scripts/sh/sandbox_deletion.sh
+++ b/aws/scripts/sh/sandbox_deletion.sh
@@ -1,36 +1,101 @@
-#!/bin/bash
+#!/bin/sh
 
-# Check for all required variables
-if [ -z "${PROJECT_NAME}" ] || [ -z "${BRANCH_NAME}" ] || [ -z "${AWS_DEFAULT_REGION}" ]; then
+set -eu
+
+if [ -z "${PROJECT_NAME:-}" ] || [ -z "${BRANCH_NAME:-}" ] || [ -z "${AWS_DEFAULT_REGION:-}" ]; then
     echo "Error: PROJECT_NAME, BRANCH_NAME, and AWS_DEFAULT_REGION variables must be set."
     echo "Usage: Make sure all environment variables are set before running the script."
     exit 1
 fi
 
-BUCKET_NAME="${PROJECT_NAME}-${BRANCH_NAME}"
+sanitize_legacy_branch_name() {
+    sanitized_branch=$(printf '%s' "$1" \
+        | tr '[:upper:]' '[:lower:]' \
+        | sed 's/[^a-z0-9.-]//g' \
+        | sed -E 's/^[.-]+|[.-]+$//g')
 
-echo "Checking if bucket ${BUCKET_NAME} exists..."
+    if [ -z "$sanitized_branch" ]; then
+        sanitized_branch="branch"
+    fi
 
-# Check if the bucket exists
-if aws s3api head-bucket --bucket "${BUCKET_NAME}" --region "${AWS_DEFAULT_REGION}" 2>/dev/null; then
-    echo "Bucket ${BUCKET_NAME} exists. Proceeding with deletion..."
-else
-    echo "Bucket ${BUCKET_NAME} does not exist. Exiting."
-    exit 0
+    printf '%s' "$sanitized_branch" | cut -c 1-47
+}
+
+delete_cleanup_rule() {
+    bucket_name="$1"
+    rule_name="sandbox-cleanup-$(printf '%s' "$bucket_name" | sed 's/\./-/g' | cut -c1-44)"
+
+    if ! aws events describe-rule --name "$rule_name" --region "${AWS_DEFAULT_REGION}" >/dev/null 2>&1; then
+        echo "Cleanup rule ${rule_name} does not exist."
+        return 0
+    fi
+
+    target_ids=$(aws events list-targets-by-rule \
+        --rule "$rule_name" \
+        --region "${AWS_DEFAULT_REGION}" \
+        --query 'Targets[].Id' \
+        --output text)
+
+    if [ -n "$target_ids" ] && [ "$target_ids" != "None" ]; then
+        echo "Removing EventBridge targets from ${rule_name}..."
+        # shellcheck disable=SC2086 # AWS CLI expects one argument per target id.
+        aws events remove-targets --rule "$rule_name" --ids $target_ids --region "${AWS_DEFAULT_REGION}" >/dev/null
+    fi
+
+    echo "Deleting EventBridge cleanup rule ${rule_name}..."
+    aws events delete-rule --name "$rule_name" --region "${AWS_DEFAULT_REGION}"
+}
+
+delete_bucket() {
+    bucket_name="$1"
+
+    echo "Checking if bucket ${bucket_name} exists..."
+    if ! aws s3api head-bucket --bucket "${bucket_name}" --region "${AWS_DEFAULT_REGION}" 2>/dev/null; then
+        echo "Bucket ${bucket_name} does not exist."
+        return 1
+    fi
+
+    echo "Bucket ${bucket_name} exists. Proceeding with deletion..."
+    delete_cleanup_rule "${bucket_name}"
+
+    if aws s3 rm "s3://${bucket_name}" --recursive --region "${AWS_DEFAULT_REGION}"; then
+        echo "All objects were successfully removed from bucket ${bucket_name}."
+    else
+        echo "Error deleting objects from bucket ${bucket_name}."
+        exit 1
+    fi
+
+    if aws s3api delete-bucket --bucket "${bucket_name}" --region "${AWS_DEFAULT_REGION}"; then
+        echo "Bucket ${bucket_name} delete request completed."
+    else
+        echo "Error deleting bucket ${bucket_name}."
+        exit 1
+    fi
+
+    if aws s3api head-bucket --bucket "${bucket_name}" --region "${AWS_DEFAULT_REGION}" 2>/dev/null; then
+        echo "Bucket ${bucket_name} still exists after deletion."
+        exit 1
+    fi
+
+    echo "Bucket ${bucket_name} was successfully deleted."
+    return 0
+}
+
+raw_branch_name="${RAW_BRANCH_NAME:-${BRANCH_NAME}}"
+legacy_branch_name=$(sanitize_legacy_branch_name "${raw_branch_name}")
+legacy_bucket_name="${PROJECT_NAME}-${legacy_branch_name}"
+current_bucket_name="${PROJECT_NAME}-${BRANCH_NAME}"
+
+deleted_any_bucket=0
+
+if delete_bucket "${current_bucket_name}"; then
+    deleted_any_bucket=1
 fi
 
-# Removing objects from a bucket
-if aws s3 rm "s3://${BUCKET_NAME}" --recursive --region "${AWS_DEFAULT_REGION}"; then
-    echo "All objects were successfully removed from bucket ${BUCKET_NAME}."
-else
-    echo "Error deleting objects from bucket ${BUCKET_NAME}."
-    exit 1
+if [ "${legacy_bucket_name}" != "${current_bucket_name}" ] && delete_bucket "${legacy_bucket_name}"; then
+    deleted_any_bucket=1
 fi
 
-# Removing a bucket
-if aws s3api delete-bucket --bucket "${BUCKET_NAME}" --region "${AWS_DEFAULT_REGION}"; then
-    echo "Bucket ${BUCKET_NAME} was successfully deleted."
-else
-    echo "Error deleting bucket ${BUCKET_NAME}."
-    exit 1
+if [ "${deleted_any_bucket}" -eq 0 ]; then
+    echo "No matching sandbox buckets were found for deletion."
 fi

--- a/terraform/app/modules/aws/iam/roles/sandbox-deletion-role/policy.tf
+++ b/terraform/app/modules/aws/iam/roles/sandbox-deletion-role/policy.tf
@@ -48,8 +48,22 @@ resource "aws_iam_policy" "codepipeline_policy" {
           "arn:aws:s3:::${var.project_name}-codebuild-logs-${var.environment}",
           "arn:aws:s3:::${var.project_name}-codebuild-logs-${var.environment}/*",
           "arn:aws:s3:::${var.project_name}-access-logs-${var.environment}",
+          "arn:aws:s3:::sandbox-${var.environment}-${var.LEGACY_SANITIZED_BRANCH_NAME}",
+          "arn:aws:s3:::sandbox-${var.environment}-${var.LEGACY_SANITIZED_BRANCH_NAME}/*",
           "arn:aws:s3:::sandbox-${var.environment}-${var.SANITIZED_BRANCH_NAME}*",
           "arn:aws:s3:::sandbox-${var.environment}-${var.SANITIZED_BRANCH_NAME}*/*"
+        ]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "events:DescribeRule",
+          "events:ListTargetsByRule",
+          "events:RemoveTargets",
+          "events:DeleteRule"
+        ],
+        Resource = [
+          "arn:aws:events:${var.region}:${var.account_id}:rule/sandbox-cleanup-sandbox-${var.environment}-*"
         ]
       },
     ]
@@ -104,8 +118,22 @@ resource "aws_iam_policy" "codebuild_policy" {
           "arn:aws:s3:::${var.project_name}-codepipeline-artifacts-${var.environment}/*",
           "arn:aws:s3:::${var.project_name}-codebuild-logs-${var.environment}/*",
           "arn:aws:s3:::${var.project_name}-access-logs-${var.environment}/*",
+          "arn:aws:s3:::sandbox-${var.environment}-${var.LEGACY_SANITIZED_BRANCH_NAME}",
+          "arn:aws:s3:::sandbox-${var.environment}-${var.LEGACY_SANITIZED_BRANCH_NAME}/*",
           "arn:aws:s3:::sandbox-${var.environment}-${var.SANITIZED_BRANCH_NAME}*",
           "arn:aws:s3:::sandbox-${var.environment}-${var.SANITIZED_BRANCH_NAME}*/*"
+        ]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "events:DescribeRule",
+          "events:ListTargetsByRule",
+          "events:RemoveTargets",
+          "events:DeleteRule"
+        ],
+        Resource = [
+          "arn:aws:events:${var.region}:${var.account_id}:rule/sandbox-cleanup-sandbox-${var.environment}-*"
         ]
       },
       {

--- a/terraform/app/modules/aws/iam/roles/sandbox-deletion-role/variables.tf
+++ b/terraform/app/modules/aws/iam/roles/sandbox-deletion-role/variables.tf
@@ -43,3 +43,8 @@ variable "SANITIZED_BRANCH_NAME" {
   description = "Bucket-safe branch suffix used by sandbox resources"
   type        = string
 }
+
+variable "LEGACY_SANITIZED_BRANCH_NAME" {
+  description = "Legacy pre-hash sandbox bucket suffix used before branch hashing was introduced"
+  type        = string
+}

--- a/terraform/app/stacks/ci-cd-infrastructure/locals.tf
+++ b/terraform/app/stacks/ci-cd-infrastructure/locals.tf
@@ -273,6 +273,9 @@ locals {
   sandbox_branch_hash               = substr(sha1(var.BRANCH_NAME), 0, local.sandbox_branch_hash_length)
   sandbox_branch_slug               = replace(lower(var.BRANCH_NAME), "/[^a-z0-9]+/", "-")
   sandbox_branch_trimmed            = replace(local.sandbox_branch_slug, "/^-+|-+$/", "")
+  legacy_sandbox_branch_raw         = replace(lower(var.BRANCH_NAME), "/[^a-z0-9.-]/", "")
+  legacy_sandbox_branch_trimmed     = replace(local.legacy_sandbox_branch_raw, "/^[.-]+|[.-]+$/", "")
+  legacy_sandbox_branch_name        = local.legacy_sandbox_branch_trimmed != "" ? substr(local.legacy_sandbox_branch_trimmed, 0, min(47, length(local.legacy_sandbox_branch_trimmed))) : "branch"
   sandbox_branch_base               = local.sandbox_branch_trimmed != "" ? local.sandbox_branch_trimmed : "branch"
   sandbox_bucket_suffix_max_length  = max(10, 63 - length(var.sandbox_project_name) - 1)
   sandbox_bucket_hash_suffix_length = local.sandbox_branch_hash_length + 1

--- a/terraform/app/stacks/ci-cd-infrastructure/sandbox_deletion.tf
+++ b/terraform/app/stacks/ci-cd-infrastructure/sandbox_deletion.tf
@@ -1,10 +1,10 @@
 module "iam_roles" {
-  source                  = "../../modules/aws/iam/roles/sandbox-deletion-role"
-  project_name            = var.project_name
-  environment             = var.environment
-  region                  = var.region
-  account_id              = data.aws_caller_identity.current.account_id
-  codestar_connection_arn = module.codestar_connection.arn
+  source                       = "../../modules/aws/iam/roles/sandbox-deletion-role"
+  project_name                 = var.project_name
+  environment                  = var.environment
+  region                       = var.region
+  account_id                   = data.aws_caller_identity.current.account_id
+  codestar_connection_arn      = module.codestar_connection.arn
   SANITIZED_BRANCH_NAME        = local.sanitized_sandbox_branch_name
   LEGACY_SANITIZED_BRANCH_NAME = local.legacy_sandbox_branch_name
 }

--- a/terraform/app/stacks/ci-cd-infrastructure/sandbox_deletion.tf
+++ b/terraform/app/stacks/ci-cd-infrastructure/sandbox_deletion.tf
@@ -5,7 +5,8 @@ module "iam_roles" {
   region                  = var.region
   account_id              = data.aws_caller_identity.current.account_id
   codestar_connection_arn = module.codestar_connection.arn
-  SANITIZED_BRANCH_NAME   = local.sanitized_sandbox_branch_name
+  SANITIZED_BRANCH_NAME        = local.sanitized_sandbox_branch_name
+  LEGACY_SANITIZED_BRANCH_NAME = local.legacy_sandbox_branch_name
 }
 
 module "s3_buckets" {


### PR DESCRIPTION
# Pull Request Template

## Description
Fix website sandbox deletion so it can clean up both the current hashed sandbox bucket name and legacy pre-hash sandbox bucket names.

## Related Issue
Closes #116

## Motivation and Context
Sandbox deletion currently sanitizes the branch name into the hashed bucket suffix introduced in #99. Older sandboxes still use the legacy unhashed bucket name, so the delete build can report success while leaving the real sandbox bucket behind. This change makes deletion cover both naming schemes, verifies the bucket is actually gone, and removes the matching EventBridge cleanup rule.

## How Has This Been Tested?
- `bash -n aws/scripts/sh/sandbox_deletion.sh`
- `git diff --check`
- Reproduced against the live test sandbox bucket `sandbox-test-137-refactor-sandbox-deleting` using the patched script locally; objects were deleted and `head-bucket` returned 404 afterward
- Confirmed the current CodeBuild logs were targeting the hashed bucket `sandbox-test-137-refactor-sandbox-deleting-54601b72` while the real legacy bucket name was unhashed

## Screenshots (if appropriate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING.md**](https://github.com/VilnaCRM-Org/infrastructure-template/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] You have only one commit (if not, squash them into one commit).
