### PR TITLE
fix: broaden website sandbox deletion IAM scope

### DIFF
--- a/terraform/app/modules/aws/iam/roles/sandbox-deletion-role/policy.tf
+++ b/terraform/app/modules/aws/iam/roles/sandbox-deletion-role/policy.tf
@@ -48,10 +48,8 @@ resource "aws_iam_policy" "codepipeline_policy" {
           "arn:aws:s3:::${var.project_name}-codebuild-logs-${var.environment}",
           "arn:aws:s3:::${var.project_name}-codebuild-logs-${var.environment}/*",
           "arn:aws:s3:::${var.project_name}-access-logs-${var.environment}",
-          "arn:aws:s3:::sandbox-${var.environment}-${var.LEGACY_SANITIZED_BRANCH_NAME}",
-          "arn:aws:s3:::sandbox-${var.environment}-${var.LEGACY_SANITIZED_BRANCH_NAME}/*",
-          "arn:aws:s3:::sandbox-${var.environment}-${var.SANITIZED_BRANCH_NAME}*",
-          "arn:aws:s3:::sandbox-${var.environment}-${var.SANITIZED_BRANCH_NAME}*/*"
+          "arn:aws:s3:::sandbox-${var.environment}-*",
+          "arn:aws:s3:::sandbox-${var.environment}-*/*"
         ]
       },
       {
@@ -118,10 +116,8 @@ resource "aws_iam_policy" "codebuild_policy" {
           "arn:aws:s3:::${var.project_name}-codepipeline-artifacts-${var.environment}/*",
           "arn:aws:s3:::${var.project_name}-codebuild-logs-${var.environment}/*",
           "arn:aws:s3:::${var.project_name}-access-logs-${var.environment}/*",
-          "arn:aws:s3:::sandbox-${var.environment}-${var.LEGACY_SANITIZED_BRANCH_NAME}",
-          "arn:aws:s3:::sandbox-${var.environment}-${var.LEGACY_SANITIZED_BRANCH_NAME}/*",
-          "arn:aws:s3:::sandbox-${var.environment}-${var.SANITIZED_BRANCH_NAME}*",
-          "arn:aws:s3:::sandbox-${var.environment}-${var.SANITIZED_BRANCH_NAME}*/*"
+          "arn:aws:s3:::sandbox-${var.environment}-*",
+          "arn:aws:s3:::sandbox-${var.environment}-*/*"
         ]
       },
       {

--- a/terraform/app/modules/aws/iam/roles/sandbox-deletion-role/variables.tf
+++ b/terraform/app/modules/aws/iam/roles/sandbox-deletion-role/variables.tf
@@ -38,13 +38,3 @@ variable "codestar_connection_arn" {
   description = "CodeStar connection ARN"
   type        = string
 }
-
-variable "SANITIZED_BRANCH_NAME" {
-  description = "Bucket-safe branch suffix used by sandbox resources"
-  type        = string
-}
-
-variable "LEGACY_SANITIZED_BRANCH_NAME" {
-  description = "Legacy pre-hash sandbox bucket suffix used before branch hashing was introduced"
-  type        = string
-}

--- a/terraform/app/stacks/ci-cd-infrastructure/locals.tf
+++ b/terraform/app/stacks/ci-cd-infrastructure/locals.tf
@@ -273,9 +273,6 @@ locals {
   sandbox_branch_hash               = substr(sha1(var.BRANCH_NAME), 0, local.sandbox_branch_hash_length)
   sandbox_branch_slug               = replace(lower(var.BRANCH_NAME), "/[^a-z0-9]+/", "-")
   sandbox_branch_trimmed            = replace(local.sandbox_branch_slug, "/^-+|-+$/", "")
-  legacy_sandbox_branch_raw         = replace(lower(var.BRANCH_NAME), "/[^a-z0-9.-]/", "")
-  legacy_sandbox_branch_trimmed     = replace(local.legacy_sandbox_branch_raw, "/^[.-]+|[.-]+$/", "")
-  legacy_sandbox_branch_name        = local.legacy_sandbox_branch_trimmed != "" ? substr(local.legacy_sandbox_branch_trimmed, 0, min(47, length(local.legacy_sandbox_branch_trimmed))) : "branch"
   sandbox_branch_base               = local.sandbox_branch_trimmed != "" ? local.sandbox_branch_trimmed : "branch"
   sandbox_bucket_suffix_max_length  = max(10, 63 - length(var.sandbox_project_name) - 1)
   sandbox_bucket_hash_suffix_length = local.sandbox_branch_hash_length + 1

--- a/terraform/app/stacks/ci-cd-infrastructure/sandbox_deletion.tf
+++ b/terraform/app/stacks/ci-cd-infrastructure/sandbox_deletion.tf
@@ -1,12 +1,10 @@
 module "iam_roles" {
-  source                       = "../../modules/aws/iam/roles/sandbox-deletion-role"
-  project_name                 = var.project_name
-  environment                  = var.environment
-  region                       = var.region
-  account_id                   = data.aws_caller_identity.current.account_id
-  codestar_connection_arn      = module.codestar_connection.arn
-  SANITIZED_BRANCH_NAME        = local.sanitized_sandbox_branch_name
-  LEGACY_SANITIZED_BRANCH_NAME = local.legacy_sandbox_branch_name
+  source                  = "../../modules/aws/iam/roles/sandbox-deletion-role"
+  project_name            = var.project_name
+  environment             = var.environment
+  region                  = var.region
+  account_id              = data.aws_caller_identity.current.account_id
+  codestar_connection_arn = module.codestar_connection.arn
 }
 
 module "s3_buckets" {


### PR DESCRIPTION
## Summary
- broaden sandbox deletion IAM from compile-time branch names to sandbox-prod-* / sandbox-test-*
- keep EventBridge cleanup-rule deletion permissions in place
- remove branch-specific Terraform wiring that caused branch-da39a3ee policies

## Validation
- reproduced the prod sandbox deletion failure for codex-website-swagger-network-failure-webkit
- confirmed the failing role was scoped to sandbox-prod-branch and sandbox-prod-branch-da39a3ee*
- validated the broadened policy shape locally and drove it through the prod shared-infra pipeline from the hotfix branch

Fixes #118