### PR TITLE
fix(iam): refresh website OIDC trust policies

### DIFF
--- a/.github/workflows/ci-cd-infra.yml
+++ b/.github/workflows/ci-cd-infra.yml
@@ -24,9 +24,30 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_CI_CD_INFRA_ROLE_TO_ASSUME_TEST }}
+          role-to-assume: arn:aws:iam::${{vars.TEST_AWS_ACCOUNT_ID}}:role/ci-cd-infra-trigger-role
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Trigger CodePipeline
         run: |
-          aws codepipeline start-pipeline-execution --name ci-cd-infra-test-pipeline
+          set +e
+          OUTPUT=$(aws codepipeline start-pipeline-execution \
+            --name ci-cd-infra-test-pipeline \
+            --source-revisions "actionName=Download-Source,revisionType=COMMIT_ID,revisionValue=${GITHUB_SHA}" 2>&1)
+          STATUS=$?
+          set -e
+
+          if [ "${STATUS}" -eq 0 ]; then
+            echo "${OUTPUT}"
+            exit 0
+          fi
+
+          echo "${OUTPUT}"
+
+          if echo "${OUTPUT}" | grep -q "Source revisions can only be used with V2 pipelines"; then
+            echo "::warning::ci-cd-infra-test-pipeline is still V1; starting without a source revision override until the V2 pipeline update is applied."
+            aws codepipeline start-pipeline-execution --name ci-cd-infra-test-pipeline
+            exit 0
+          fi
+
+          echo "::error::Failed to start V2 pipeline with source revision ${GITHUB_SHA}."
+          exit 1

--- a/.github/workflows/oidc-trust-smoke-test.yml
+++ b/.github/workflows/oidc-trust-smoke-test.yml
@@ -1,0 +1,59 @@
+name: OIDC trust smoke test
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "29 7 * * *"
+
+env:
+  AWS_REGION: ${{ vars.AWS_REGION }}
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  assume-roles:
+    name: assume ${{ matrix.account }} ${{ matrix.role }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - account: test
+            account_id: ${{ vars.TEST_AWS_ACCOUNT_ID }}
+            role: github-actions-role
+          - account: prod
+            account_id: ${{ vars.PROD_AWS_ACCOUNT_ID }}
+            role: github-actions-role
+          - account: prod
+            account_id: ${{ vars.PROD_AWS_ACCOUNT_ID }}
+            role: website-deploy-trigger-role
+          - account: prod
+            account_id: ${{ vars.PROD_AWS_ACCOUNT_ID }}
+            role: sandbox-creation-trigger-role
+          - account: prod
+            account_id: ${{ vars.PROD_AWS_ACCOUNT_ID }}
+            role: sandbox-deletion-trigger-role
+
+    steps:
+      - name: Validate inputs
+        run: |
+          if [ -z "${AWS_REGION}" ]; then
+            echo "::error::AWS_REGION is not set"
+            exit 1
+          fi
+          if [ -z "${{ matrix.account_id }}" ]; then
+            echo "::error::AWS account ID is not set for ${{ matrix.account }}"
+            exit 1
+          fi
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ matrix.account_id }}:role/${{ matrix.role }}
+          role-session-name: GitHubOidcTrustSmokeTest
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Verify caller identity
+        run: aws sts get-caller-identity

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -20,9 +20,9 @@ jobs:
       - name: Run tfsec
         uses: aquasecurity/tfsec-action@b466648d6e39e7c75324f25d83891162a721f2d6
         with:
+          version: v1.28.14
           format: sarif
           additional_args: --out tfsec.sarif
-          github_token: ${{ github.token }}
 
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98

--- a/aws/buildspecs/ci-cd-infrastructure/validate.yml
+++ b/aws/buildspecs/ci-cd-infrastructure/validate.yml
@@ -3,6 +3,7 @@ version: 0.2
 env:
   variables:
     TFSEC_VERSION: "v1.28.5"
+    GO_TASK_VERSION: "v3.49.0"
     TS_TERRAFORM_BIN: "terraform"
     TS_VERSION_CHECK: "0"
 
@@ -21,7 +22,7 @@ phases:
       - "echo ## Install Validation Software"
       - "pip3 install checkov"
       - "curl -s https://raw.githubusercontent.com/aquasecurity/tfsec/master/scripts/install_linux.sh | bash"
-      - "go install github.com/go-task/task/v3/cmd/task@latest"
+      - "go install github.com/go-task/task/v3/cmd/task@${GO_TASK_VERSION}"
   build:
     commands:
       - "cd ${CODEBUILD_SRC_DIR}"

--- a/aws/buildspecs/ci-cd-infrastructure/validate.yml
+++ b/aws/buildspecs/ci-cd-infrastructure/validate.yml
@@ -2,7 +2,7 @@ version: 0.2
 
 env:
   variables:
-    TFSEC_VERSION: "v1.28.5"
+    TFSEC_VERSION: "v1.28.14"
     GO_TASK_VERSION: "v3.49.0"
     TS_TERRAFORM_BIN: "terraform"
     TS_VERSION_CHECK: "0"
@@ -21,7 +21,7 @@ phases:
       - "dnf update -y"
       - "echo ## Install Validation Software"
       - "pip3 install checkov"
-      - "curl -s https://raw.githubusercontent.com/aquasecurity/tfsec/master/scripts/install_linux.sh | bash"
+      - "curl -fsSL https://raw.githubusercontent.com/aquasecurity/tfsec/${TFSEC_VERSION}/scripts/install_linux.sh | bash"
       - "go install github.com/go-task/task/v3/cmd/task@${GO_TASK_VERSION}"
   build:
     commands:

--- a/aws/buildspecs/ci-cd-infrastructure/validate.yml
+++ b/aws/buildspecs/ci-cd-infrastructure/validate.yml
@@ -21,7 +21,7 @@ phases:
       - "dnf update -y"
       - "echo ## Install Validation Software"
       - "pip3 install checkov"
-      - "curl -fsSL https://raw.githubusercontent.com/aquasecurity/tfsec/${TFSEC_VERSION}/scripts/install_linux.sh | bash"
+      - "curl -fsSL https://raw.githubusercontent.com/aquasecurity/tfsec/${TFSEC_VERSION}/scripts/install_linux.sh -o /tmp/install_tfsec.sh && bash /tmp/install_tfsec.sh"
       - "go install github.com/go-task/task/v3/cmd/task@${GO_TASK_VERSION}"
   build:
     commands:

--- a/aws/buildspecs/website/validate.yml
+++ b/aws/buildspecs/website/validate.yml
@@ -3,6 +3,7 @@ version: 0.2
 env:
   variables:
     TFSEC_VERSION: "v1.28.5"
+    GO_TASK_VERSION: "v3.49.0"
 
 phases:
   install:
@@ -17,7 +18,7 @@ phases:
       - "dnf install -y jq yum-utils"
       - "pip3 install checkov"
       - "curl -s https://raw.githubusercontent.com/aquasecurity/tfsec/master/scripts/install_linux.sh | bash"
-      - "go install github.com/go-task/task/v3/cmd/task@latest"
+      - "go install github.com/go-task/task/v3/cmd/task@${GO_TASK_VERSION}"
   build:
     commands:
       - "cd ${CODEBUILD_SRC_DIR}"

--- a/aws/buildspecs/website/validate.yml
+++ b/aws/buildspecs/website/validate.yml
@@ -17,7 +17,7 @@ phases:
       - "dnf update -y"
       - "dnf install -y jq yum-utils"
       - "pip3 install checkov"
-      - "curl -fsSL https://raw.githubusercontent.com/aquasecurity/tfsec/${TFSEC_VERSION}/scripts/install_linux.sh | bash"
+      - "curl -fsSL https://raw.githubusercontent.com/aquasecurity/tfsec/${TFSEC_VERSION}/scripts/install_linux.sh -o /tmp/install_tfsec.sh && bash /tmp/install_tfsec.sh"
       - "go install github.com/go-task/task/v3/cmd/task@${GO_TASK_VERSION}"
   build:
     commands:

--- a/aws/buildspecs/website/validate.yml
+++ b/aws/buildspecs/website/validate.yml
@@ -2,7 +2,7 @@ version: 0.2
 
 env:
   variables:
-    TFSEC_VERSION: "v1.28.5"
+    TFSEC_VERSION: "v1.28.14"
     GO_TASK_VERSION: "v3.49.0"
 
 phases:
@@ -17,7 +17,7 @@ phases:
       - "dnf update -y"
       - "dnf install -y jq yum-utils"
       - "pip3 install checkov"
-      - "curl -s https://raw.githubusercontent.com/aquasecurity/tfsec/master/scripts/install_linux.sh | bash"
+      - "curl -fsSL https://raw.githubusercontent.com/aquasecurity/tfsec/${TFSEC_VERSION}/scripts/install_linux.sh | bash"
       - "go install github.com/go-task/task/v3/cmd/task@${GO_TASK_VERSION}"
   build:
     commands:

--- a/terraform/app/modules/aws/codepipeline/infrastructure/main.tf
+++ b/terraform/app/modules/aws/codepipeline/infrastructure/main.tf
@@ -4,6 +4,8 @@ resource "aws_codepipeline" "terraform_pipeline" {
   role_arn = var.codepipeline_role_arn
   tags     = var.tags
 
+  pipeline_type = "V2"
+
   artifact_store {
     location = var.s3_bucket_name
     type     = "S3"

--- a/terraform/app/modules/aws/codepipeline/infrastructure/main.tf
+++ b/terraform/app/modules/aws/codepipeline/infrastructure/main.tf
@@ -1,3 +1,7 @@
+locals {
+  source_change_detection_enabled = lower(var.detect_changes) == "true"
+}
+
 resource "aws_codepipeline" "terraform_pipeline" {
   #checkov:skip=CKV_AWS_219: S3 bucket has encryption by default
   name     = "${var.project_name}-pipeline"
@@ -28,7 +32,25 @@ resource "aws_codepipeline" "terraform_pipeline" {
         ConnectionArn    = var.codestar_connection_arn
         FullRepositoryId = "${var.source_repo_owner}/${var.source_repo_name}"
         BranchName       = var.source_repo_branch
-        DetectChanges    = var.detect_changes
+        DetectChanges    = local.source_change_detection_enabled ? "false" : var.detect_changes
+      }
+    }
+  }
+
+  dynamic "trigger" {
+    for_each = local.source_change_detection_enabled ? [var.source_repo_branch] : []
+
+    content {
+      provider_type = "CodeStarSourceConnection"
+
+      git_configuration {
+        source_action_name = "Download-Source"
+
+        push {
+          branches {
+            includes = [trigger.value]
+          }
+        }
       }
     }
   }

--- a/terraform/app/modules/aws/iam/oidc/pipeline-trigger-role/main.tf
+++ b/terraform/app/modules/aws/iam/oidc/pipeline-trigger-role/main.tf
@@ -15,9 +15,16 @@ resource "aws_iam_role" "codepipeline_trigger_role" {
         }
         Action = "sts:AssumeRoleWithWebIdentity"
         Condition = {
-          StringLike = {
+          StringEquals = {
             "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
-            "token.actions.githubusercontent.com:sub" = "repo:${var.github_owner}/*"
+          }
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = [
+              "repo:${var.github_owner}/${var.github_repo}:ref:refs/heads/*",
+              "repo:${var.github_owner}/${var.github_repo}:pull_request",
+              "repo:${var.github_owner}/${var.website_repo}:ref:refs/heads/*",
+              "repo:${var.github_owner}/${var.website_repo}:pull_request"
+            ]
           }
         }
       }

--- a/terraform/app/modules/aws/iam/roles/github-token-rotation-role/main.tf
+++ b/terraform/app/modules/aws/iam/roles/github-token-rotation-role/main.tf
@@ -13,8 +13,10 @@ resource "aws_iam_role" "github_actions_role" {
           Federated = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/token.actions.githubusercontent.com"
         },
         Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          },
           StringLike = {
-            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com",
             "token.actions.githubusercontent.com:sub" = [
               "repo:${var.source_repo_owner}/${var.source_repo_name}:ref:refs/heads/main",
               "repo:${var.source_repo_owner}/${var.website_repo_name}:ref:refs/heads/*",

--- a/terraform/config/terraform/terraform.tf
+++ b/terraform/config/terraform/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = ">= 5.25.0"
+      version               = ">= 5.40.0"
       configuration_aliases = [aws.us-east-1, aws.eu-west-1]
     }
     random = {


### PR DESCRIPTION
# Pull Request Template

## Description
Refreshes website GitHub OIDC trust policies and adds guardrails so prod IAM trust drift is caught earlier.

## Related Issue
Follow-up to the CRM OIDC drift investigation. The latest website-infrastructure prod token rotation failure was run `25078622867`, failing on `arn:aws:iam::933245420672:role/github-actions-role` with `Not authorized to perform sts:AssumeRoleWithWebIdentity`.

## Motivation and Context
Prod website token rotation is failing at AWS OIDC role assumption while the matching test rotation succeeds. The test account still has broad owner-wide trigger-role trust, and the infra CodePipeline is V1/pinned to `main`, so PR branch infra changes are not validated by the AWS pipeline. This is the same process gap that let the CRM prod trust drift survive.

## Changes
- Make GitHub OIDC `aud` checks exact with `StringEquals`.
- Replace owner-wide trigger-role `sub = repo:VilnaCRM-Org/*` with explicit `website-infrastructure` and `website` subjects.
- Add scheduled/manual OIDC smoke tests for test/prod token role, website deploy trigger role, and sandbox create/delete trigger roles.
- Convert the infra CodePipeline module to V2 and have GitHub Actions start it for the exact PR commit.
- Keep a temporary V1 fallback so this PR can bootstrap the live V2 pipeline update.
- Pin `go-task` to `v3.49.0` in CodeBuild validation buildspecs.
- Pin tfsec action to `v1.28.14` and remove the authenticated API call.

## How Has This Been Tested?
- `npx --yes prettier@3.6.2 --check .github/workflows/ci-cd-infra.yml .github/workflows/oidc-trust-smoke-test.yml .github/workflows/tfsec.yml aws/buildspecs/ci-cd-infrastructure/validate.yml aws/buildspecs/website/validate.yml`
- `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:latest -color .github/workflows/ci-cd-infra.yml .github/workflows/oidc-trust-smoke-test.yml .github/workflows/tfsec.yml`
- `docker run --rm -v "$PWD:/workspace" -w /workspace hashicorp/terraform:1.13.5 fmt -check terraform/app/modules/aws/iam/oidc/pipeline-trigger-role/main.tf terraform/app/modules/aws/iam/roles/github-token-rotation-role/main.tf terraform/app/modules/aws/codepipeline/infrastructure/main.tf`
- YAML load checks for touched workflows/buildspecs.
- `git diff --check`
- Verified local OIDC subject matching allows website PRs, website branches, infra branches, infra main token rotation, and website PR token use.
- Verified live test account is `891377212104`; current test trigger roles still use owner-wide trust, and `ci-cd-infra-test-pipeline` is currently `V1` with source pinned to `main` commit `5731bcae75313dcd96a478c60a88d93e9c3247c0`.
- Verified `go-task@v3.49.0` installs under Go 1.24; `v3.50.0` reproduces the Go `>= 1.25.8` failure.

## Screenshots (if appropriate)
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING.md**](https://github.com/VilnaCRM-Org/infrastructure-template/blob/main/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] You have only one commit (if not, squash them into one commit).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes website GitHub OIDC trust to fix prod role assumption failures and prevent drift. Adds OIDC smoke tests, upgrades the infra pipeline to V2 with per-commit runs and a safe V1 fallback, and hardens `tfsec` installation.

- **Bug Fixes**
  - Tightened OIDC trust: `aud` uses StringEquals; `sub` limited to `website-infrastructure` and `website` branches and PRs.
  - Applies to the token rotation role and the pipeline trigger role, resolving prod “Not authorized to perform sts:AssumeRoleWithWebIdentity”.
  - Hardened `tfsec` install in CodeBuild: version-pinned script download with `-fsSL`, no curl | bash.

- **New Features**
  - Scheduled/manual OIDC smoke tests for test/prod token role and prod deploy/sandbox trigger roles.
  - CodePipeline set to V2; CI starts the pipeline for the exact PR commit with automatic V1 fallback. Adds V2 push triggers when change detection is enabled.
  - Upgraded Terraform `aws` provider to `>= 5.40.0`; pinned `go-task` to `v3.49.0` and `tfsec` to `v1.28.14`.

<sup>Written for commit 46de518724a1faf00277fd396d3a85e8be39cfb2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

